### PR TITLE
Update lv_anim_timeline.c

### DIFF
--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -92,7 +92,7 @@ uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at)
     uint32_t end = at->reverse ? 0 : playtime;
     uint32_t duration = end > start ? end - start : start - end;
 
-    if( (!at->reverse && at->act_time == 0) || (at->reverse && at->act_time== playtime ) )
+    if((!at->reverse && at->act_time == 0) || (at->reverse && at->act_time== playtime) )
     {
         for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
             at->anim_dsc[i].is_started   = false;
@@ -180,12 +180,15 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
 
         uint32_t start_time = at->anim_dsc[i].start_time;
         int32_t value = 0;
-        
+
         if(act_time < start_time && a->early_apply) {
-            if(at->reverse){
-                if(!at->anim_dsc[i].is_started && a->start_cb) a->start_cb(a);
+            if(at->reverse) {
+                if(!at->anim_dsc[i].is_started && a->start_cb) {
+                    a->start_cb(a);
+                }
                 at->anim_dsc[i].is_started   = true;
-            }else{
+            } 
+            else {
                 at->anim_dsc[i].is_started   = false;
             }
 
@@ -193,45 +196,56 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
 
-            if(at->reverse){
-                if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+            if(at->reverse) {
+                if(!at->anim_dsc[i].is_completed && a->completed_cb) {
+                    a->completed_cb(a);
+                }
                 at->anim_dsc[i].is_completed = true;
-            }else{
+            }
+            else {
                 at->anim_dsc[i].is_completed = false;
             }
         }
         else if(act_time >= start_time && act_time <= (start_time + a->duration)) {
-
-            if(!at->anim_dsc[i].is_started &&  a->start_cb ) a->start_cb(a);
+            if(!at->anim_dsc[i].is_started &&  a->start_cb ) {
+                a->start_cb(a);
+            }
             at->anim_dsc[i].is_started = true;
-
 
             a->act_time = act_time - start_time;
             value = a->path_cb(a);
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
 
-            if(at->reverse){
+            if(at->reverse) {
                 if(act_time == start_time) {
-                    if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+                    if(!at->anim_dsc[i].is_completed && a->completed_cb) {
+                        a->completed_cb(a);
+                    }
                     at->anim_dsc[i].is_completed = true;
-                }else{
+                } else {
                     at->anim_dsc[i].is_completed = false;
                 }
-            }else{
+            }
+            else {
                 if(act_time == (start_time + a->duration)) {
-                    if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+                    if(!at->anim_dsc[i].is_completed && a->completed_cb) {
+                        a->completed_cb(a);
+                    }
                     at->anim_dsc[i].is_completed = true;
-                }else{
+                } else {
                     at->anim_dsc[i].is_completed = false;
                 }
             }
         }
         else if(act_time > start_time + a->duration) {
-            if(at->reverse){
+            if(at->reverse) {
                 at->anim_dsc[i].is_started   = false;
-            }else{
-                if(!at->anim_dsc[i].is_started   && a->start_cb)     a->start_cb(a);
+            }
+            else {
+                if(!at->anim_dsc[i].is_started && a->start_cb) {
+                    a->start_cb(a);
+                }
                 at->anim_dsc[i].is_started   = true;
             }
 
@@ -239,10 +253,13 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
 
-            if(at->reverse){
+            if(at->reverse) {
                 at->anim_dsc[i].is_completed = false;
-            }else{
-                if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+            }
+            else {
+                if(!at->anim_dsc[i].is_completed && a->completed_cb) {
+                    a->completed_cb(a);
+                }
                 at->anim_dsc[i].is_completed = true;
             }
         }

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -22,6 +22,7 @@
 typedef struct {
     lv_anim_t anim;
     uint32_t start_time;
+    bool flag_completed;
 } lv_anim_timeline_dsc_t;
 
 /*Data of anim_timeline*/
@@ -185,6 +186,20 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
             value = a->end_value;
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
+        }
+ 
+        if(at->reverse) {
+            if(value > a->start_value) at->anim_dsc[i].flag_completed = false;
+            else if (value == a->start_value) {
+                if(! at->anim_dsc[i].flag_completed && a->completed_cb) a->completed_cb(a); 
+                at->anim_dsc[i].flag_completed = true;
+            }
+        }else{
+            if(value < a->end_value) at->anim_dsc[i].flag_completed = false;
+            else if (value == a->end_value) {
+                if(! at->anim_dsc[i].flag_completed && a->completed_cb) a->completed_cb(a); 
+                at->anim_dsc[i].flag_completed = true;
+            }
         }
     }
 }

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -171,7 +171,6 @@ uint16_t lv_anim_timeline_get_progress(lv_anim_timeline_t * at)
 static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_time)
 {
     at->act_time = act_time;
-    uint32_t playtime = lv_anim_timeline_get_playtime(at);
     for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
         lv_anim_t * a = &(at->anim_dsc[i].anim);
 

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -92,8 +92,7 @@ uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at)
     uint32_t end = at->reverse ? 0 : playtime;
     uint32_t duration = end > start ? end - start : start - end;
 
-    if((!at->reverse && at->act_time == 0) || (at->reverse && at->act_time == playtime))
-    {
+    if((!at->reverse && at->act_time == 0) || (at->reverse && at->act_time == playtime)) {
         for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
             at->anim_dsc[i].is_started   = 0;
             at->anim_dsc[i].is_completed = 0;
@@ -171,7 +170,7 @@ uint16_t lv_anim_timeline_get_progress(lv_anim_timeline_t * at)
 static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_time)
 {
     at->act_time = act_time;
-    bool anim_timeline_is_started = (lv_anim_get(at, anim_timeline_exec_cb)!=NULL);
+    bool anim_timeline_is_started = (lv_anim_get(at, anim_timeline_exec_cb) != NULL);
     for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
         lv_anim_timeline_dsc_t * anim_dsc = &(at->anim_dsc[i]);
         lv_anim_t * a = &(anim_dsc->anim);
@@ -188,7 +187,7 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
                 if(at->reverse) {
                     if(!anim_dsc->is_started && a->start_cb)  a->start_cb(a);
                     anim_dsc->is_started = 1;
-                } 
+                }
                 else {
                     anim_dsc->is_started = 0;
                 }
@@ -224,7 +223,7 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
                     if(act_time == start_time) {
                         if(!anim_dsc->is_completed && a->completed_cb) a->completed_cb(a);
                         anim_dsc->is_completed = 1;
-                    } 
+                    }
                     else {
                         anim_dsc->is_completed = 0;
                     }
@@ -233,7 +232,7 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
                     if(act_time == (start_time + a->duration)) {
                         if(!anim_dsc->is_completed && a->completed_cb) a->completed_cb(a);
                         anim_dsc->is_completed = 1;
-                    } 
+                    }
                     else {
                         anim_dsc->is_completed = 0;
                     }

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -22,7 +22,8 @@
 typedef struct {
     lv_anim_t anim;
     uint32_t start_time;
-    bool flag_completed;
+    bool is_started;
+    bool is_completed;
 } lv_anim_timeline_dsc_t;
 
 /*Data of anim_timeline*/
@@ -90,6 +91,14 @@ uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at)
     uint32_t start = at->act_time;
     uint32_t end = at->reverse ? 0 : playtime;
     uint32_t duration = end > start ? end - start : start - end;
+
+    if( (!at->reverse && at->act_time == 0) || (at->reverse && at->act_time== playtime ) )
+    {
+        for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
+            at->anim_dsc[i].is_started   = false;
+            at->anim_dsc[i].is_completed = false;
+        }
+    }
 
     lv_anim_t a;
     lv_anim_init(&a);
@@ -162,6 +171,7 @@ uint16_t lv_anim_timeline_get_progress(lv_anim_timeline_t * at)
 static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_time)
 {
     at->act_time = act_time;
+    uint32_t playtime = lv_anim_timeline_get_playtime(at);
     for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
         lv_anim_t * a = &(at->anim_dsc[i].anim);
 
@@ -171,34 +181,70 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
 
         uint32_t start_time = at->anim_dsc[i].start_time;
         int32_t value = 0;
+        
         if(act_time < start_time && a->early_apply) {
+            if(at->reverse){
+                if(!at->anim_dsc[i].is_started && a->start_cb) a->start_cb(a);
+                at->anim_dsc[i].is_started   = true;
+            }else{
+                at->anim_dsc[i].is_started   = false;
+            }
+
             value = a->start_value;
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
+
+            if(at->reverse){
+                if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+                at->anim_dsc[i].is_completed = true;
+            }else{
+                at->anim_dsc[i].is_completed = false;
+            }
         }
         else if(act_time >= start_time && act_time <= (start_time + a->duration)) {
+
+            if(!at->anim_dsc[i].is_started &&  a->start_cb ) a->start_cb(a);
+            at->anim_dsc[i].is_started = true;
+
+
             a->act_time = act_time - start_time;
             value = a->path_cb(a);
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
+
+            if(at->reverse){
+                if(act_time == start_time) {
+                    if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+                    at->anim_dsc[i].is_completed = true;
+                }else{
+                    at->anim_dsc[i].is_completed = false;
+                }
+            }else{
+                if(act_time == (start_time + a->duration)) {
+                    if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+                    at->anim_dsc[i].is_completed = true;
+                }else{
+                    at->anim_dsc[i].is_completed = false;
+                }
+            }
         }
         else if(act_time > start_time + a->duration) {
+            if(at->reverse){
+                at->anim_dsc[i].is_started   = false;
+            }else{
+                if(!at->anim_dsc[i].is_started   && a->start_cb)     a->start_cb(a);
+                at->anim_dsc[i].is_started   = true;
+            }
+
             value = a->end_value;
             if(a->exec_cb) a->exec_cb(a->var, value);
             if(a->custom_exec_cb) a->custom_exec_cb(a, value);
-        }
- 
-        if(at->reverse) {
-            if(value > a->start_value) at->anim_dsc[i].flag_completed = false;
-            else if (value == a->start_value) {
-                if(! at->anim_dsc[i].flag_completed && a->completed_cb) a->completed_cb(a); 
-                at->anim_dsc[i].flag_completed = true;
-            }
-        }else{
-            if(value < a->end_value) at->anim_dsc[i].flag_completed = false;
-            else if (value == a->end_value) {
-                if(! at->anim_dsc[i].flag_completed && a->completed_cb) a->completed_cb(a); 
-                at->anim_dsc[i].flag_completed = true;
+
+            if(at->reverse){
+                at->anim_dsc[i].is_completed = false;
+            }else{
+                if(!at->anim_dsc[i].is_completed && a->completed_cb) a->completed_cb(a);
+                at->anim_dsc[i].is_completed = true;
             }
         }
     }

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -95,8 +95,8 @@ uint32_t lv_anim_timeline_start(lv_anim_timeline_t * at)
     if((!at->reverse && at->act_time == 0) || (at->reverse && at->act_time == playtime))
     {
         for(uint32_t i = 0; i < at->anim_dsc_cnt; i++) {
-            at->anim_dsc[i].is_started   = false;
-            at->anim_dsc[i].is_completed = false;
+            at->anim_dsc[i].is_started   = 0;
+            at->anim_dsc[i].is_completed = 0;
         }
     }
 
@@ -201,10 +201,10 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
             if(anim_timeline_is_started) {
                 if(at->reverse) {
                     if(!anim_dsc->is_completed && a->completed_cb) a->completed_cb(a);
-                    anim_dsc->is_completed = true;
+                    anim_dsc->is_completed = 1;
                 }
                 else {
-                    anim_dsc->is_completed = false;
+                    anim_dsc->is_completed = 0;
                 }
             }
         }
@@ -223,19 +223,19 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
                 if(at->reverse) {
                     if(act_time == start_time) {
                         if(!anim_dsc->is_completed && a->completed_cb) a->completed_cb(a);
-                        anim_dsc->is_completed = true;
+                        anim_dsc->is_completed = 1;
                     } 
                     else {
-                        anim_dsc->is_completed = false;
+                        anim_dsc->is_completed = 0;
                     }
                 }
                 else {
                     if(act_time == (start_time + a->duration)) {
                         if(!anim_dsc->is_completed && a->completed_cb) a->completed_cb(a);
-                        anim_dsc->is_completed = true;
+                        anim_dsc->is_completed = 1;
                     } 
                     else {
-                        anim_dsc->is_completed = false;
+                        anim_dsc->is_completed = 0;
                     }
                 }
             }
@@ -243,11 +243,11 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
         else if(act_time > start_time + a->duration) {
             if(anim_timeline_is_started) {
                 if(at->reverse) {
-                    anim_dsc->is_started = false;
+                    anim_dsc->is_started = 0;
                 }
                 else {
                     if(!anim_dsc->is_started && a->start_cb) a->start_cb(a);
-                    anim_dsc->is_started = true;
+                    anim_dsc->is_started = 1;
                 }
             }
 
@@ -257,11 +257,11 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
 
             if(anim_timeline_is_started) {
                 if(at->reverse) {
-                    anim_dsc->is_completed = false;
+                    anim_dsc->is_completed = 0;
                 }
                 else {
                     if(!anim_dsc->is_completed && a->completed_cb) a->completed_cb(a);
-                    anim_dsc->is_completed = true;
+                    anim_dsc->is_completed = 1;
                 }
             }
         }

--- a/src/misc/lv_anim_timeline.c
+++ b/src/misc/lv_anim_timeline.c
@@ -211,7 +211,7 @@ static void anim_timeline_set_act_time(lv_anim_timeline_t * at, uint32_t act_tim
         else if(act_time >= start_time && act_time <= (start_time + a->duration)) {
             if(anim_timeline_is_started) {
                 if(!anim_dsc->is_started && a->start_cb) a->start_cb(a);
-                anim_dsc->is_started = true;
+                anim_dsc->is_started = 1;
             }
 
             a->act_time = act_time - start_time;

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -322,4 +322,77 @@ void test_anim_timeline_reverse(void)
     TEST_ASSERT_EQUAL(20, lv_obj_get_x(obj));
 }
 
+
+void anim1_exec_cb(void * var, int32_t v)
+{
+    printf("[anim1] %d\n", v);
+}
+void anim1_start(lv_anim_t * a)
+{
+    printf("[anim1] start\n");
+}
+void anim1_completed(lv_anim_t * a)
+{
+    printf("[anim1] completed\n");
+}
+
+void anim2_exec_cb(void * var, int32_t v)
+{
+    printf("                    [anim2] %d\n", v);
+}
+void anim2_start(lv_anim_t * a)
+{
+    printf("                    [anim2] start\n");
+}
+void anim2_completed(lv_anim_t * a)
+{
+    printf("                    [anim2] completed\n");
+}
+
+void anim3_exec_cb(void * var, int32_t v)
+{
+    printf("                                        [anim3] %d\n", v);
+}
+void anim3_start(lv_anim_t * a)
+{
+    printf("                                        [anim3] start\n");
+}
+void anim3_completed(lv_anim_t * a)
+{
+    printf("                                        [anim3] completed\n");
+}
+
+void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
+{
+    lv_anim_t anim1;
+    lv_anim_t anim2;
+    lv_anim_t anim3;
+
+    lv_anim_init(&anim1);
+    lv_anim_set_values(&anim1, 0, 1024);
+    lv_anim_set_duration(&anim1, 300);
+    lv_anim_set_exec_cb(&anim1, anim1_exec_cb);
+    lv_anim_set_start_cb(&anim1, anim1_start);
+    lv_anim_set_completed_cb(&anim1, anim1_completed);
+
+    lv_memcpy(&anim2, &anim1, sizeof(anim1));
+    lv_anim_set_duration(&anim2, 100);
+    lv_anim_set_path_cb(&anim2, lv_anim_path_ease_in);
+    lv_anim_set_exec_cb(&anim2, anim2_exec_cb);
+    lv_anim_set_start_cb(&anim1, anim2_start);
+    lv_anim_set_completed_cb(&anim2, anim2_completed);
+
+    lv_memcpy(&anim3, &anim1, sizeof(anim1));
+    lv_anim_set_duration(&anim3, 200);
+    lv_anim_set_exec_cb(&anim3, anim3_exec_cb);
+    lv_anim_set_start_cb(&anim1, anim3_start);
+    lv_anim_set_completed_cb(&anim3, anim3_completed);
+
+    lv_anim_timeline_t * timeline = lv_anim_timeline_create();
+    lv_anim_timeline_add(timeline,   0, &anim1);
+    lv_anim_timeline_add(timeline, 200, &anim2);
+    lv_anim_timeline_add(timeline, 400, &anim3);
+    lv_anim_timeline_start(timeline);
+}
+
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -433,51 +433,51 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
 
     lv_test_wait(10); /*Wait 10 ms*/
     TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(0, anim1_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(0, anim2_start_called);
-    TEST_ASSERT_EQUAL(0, anim2_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim2_completed_called);
     TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(200); /*Now we are at 210ms */ 
+    lv_test_wait(200); /*Now we are at 210ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(0, anim1_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(0, anim2_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim2_completed_called);
     TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(88); /*Now we are at 298ms */ 
+    lv_test_wait(88); /*Now we are at 298ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(0, anim1_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(0, anim2_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim2_completed_called);
     TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(7); /*Now we are at 305ms */ 
+    lv_test_wait(7); /*Now we are at 305ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim2_completed_called);
     TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(105); /*Now we are at 410ms */ 
+    lv_test_wait(105); /*Now we are at 410ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim2_completed_called);
     TEST_ASSERT_EQUAL(1, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called); 
+    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(200); /*Now we are at 610ms */ 
+    lv_test_wait(200); /*Now we are at 610ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim2_completed_called);
     TEST_ASSERT_EQUAL(1, anim3_start_called);
-    TEST_ASSERT_EQUAL(1, anim3_completed_called); 
+    TEST_ASSERT_EQUAL(1, anim3_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -447,7 +447,13 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(0, anim3_start_called);
     TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-
+    lv_test_wait(100); /*Now we are at 320ms */
+    TEST_ASSERT_EQUAL(1, anim1_start_called);
+    TEST_ASSERT_EQUAL(1, anim1_completed_called);
+    TEST_ASSERT_EQUAL(1, anim2_start_called);
+    TEST_ASSERT_EQUAL(1, anim2_completed_called);
+    TEST_ASSERT_EQUAL(0, anim3_start_called);
+    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -414,11 +414,6 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
 
-    lv_test_wait(100); /*Now we are at 320ms */
-    TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called);
-    TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(0, anim2_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -325,40 +325,49 @@ void test_anim_timeline_reverse(void)
 
 void anim1_exec_cb(void * var, int32_t v)
 {
+    LV_UNUSED(var);
     printf("[anim1] %d\n", v);
 }
 void anim1_start(lv_anim_t * a)
 {
+    LV_UNUSED(a);
     printf("[anim1] start\n");
 }
 void anim1_completed(lv_anim_t * a)
 {
+    LV_UNUSED(a);
     printf("[anim1] completed\n");
 }
 
 void anim2_exec_cb(void * var, int32_t v)
 {
+    LV_UNUSED(var);
     printf("                    [anim2] %d\n", v);
 }
 void anim2_start(lv_anim_t * a)
 {
+    LV_UNUSED(a);
     printf("                    [anim2] start\n");
 }
 void anim2_completed(lv_anim_t * a)
 {
+    LV_UNUSED(a);
     printf("                    [anim2] completed\n");
 }
 
 void anim3_exec_cb(void * var, int32_t v)
 {
+    LV_UNUSED(var);
     printf("                                        [anim3] %d\n", v);
 }
 void anim3_start(lv_anim_t * a)
 {
+    LV_UNUSED(a);
     printf("                                        [anim3] start\n");
 }
 void anim3_completed(lv_anim_t * a)
 {
+    LV_UNUSED(a);
     printf("                                        [anim3] completed\n");
 }
 

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -388,13 +388,13 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     lv_anim_set_duration(&anim2, 100);
     lv_anim_set_path_cb(&anim2, lv_anim_path_ease_in);
     lv_anim_set_exec_cb(&anim2, anim2_exec_cb);
-    lv_anim_set_start_cb(&anim1, anim2_start);
+    lv_anim_set_start_cb(&anim2, anim2_start);
     lv_anim_set_completed_cb(&anim2, anim2_completed);
 
     lv_memcpy(&anim3, &anim1, sizeof(anim1));
     lv_anim_set_duration(&anim3, 200);
     lv_anim_set_exec_cb(&anim3, anim3_exec_cb);
-    lv_anim_set_start_cb(&anim1, anim3_start);
+    lv_anim_set_start_cb(&anim3, anim3_start);
     lv_anim_set_completed_cb(&anim3, anim3_completed);
 
     lv_anim_timeline_t * timeline = lv_anim_timeline_create();

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -414,7 +414,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
 
-    lv_test_wait(100); /*Now we are at 320ms */
+    lv_test_wait(90); /*Now we are at 310ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -447,15 +447,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(0, anim3_start_called);
     TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(88); /*Now we are at 298ms */
-    TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(0, anim1_completed_called);
-    TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(0, anim2_completed_called);
-    TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called);
-
-    lv_test_wait(7); /*Now we are at 305ms */
+    lv_test_wait(100); /*Now we are at 310ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -9,11 +9,8 @@ static lv_anim_timeline_t * anim_timeline;
 
 static uint32_t anim1_start_called;
 static uint32_t anim2_start_called;
-static uint32_t anim3_start_called;
-
 static uint32_t anim1_completed_called;
 static uint32_t anim2_completed_called;
-static uint32_t anim3_completed_called;
 
 void setUp(void)
 {
@@ -367,29 +364,11 @@ void anim2_completed(lv_anim_t * a)
     anim2_completed_called++;
 }
 
-void anim3_exec_cb(void * var, int32_t v)
-{
-    LV_UNUSED(var);
-    printf("                                        [anim3] %d\n", v);
-}
-void anim3_start(lv_anim_t * a)
-{
-    LV_UNUSED(a);
-    printf("                                        [anim3] start\n");
-    anim3_start_called++;
-}
-void anim3_completed(lv_anim_t * a)
-{
-    LV_UNUSED(a);
-    printf("                                        [anim3] completed\n");
-    anim3_completed_called++;
-}
 
 void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
 {
     lv_anim_t anim1;
     lv_anim_t anim2;
-    lv_anim_t anim3;
 
     lv_anim_init(&anim1);
     lv_anim_set_values(&anim1, 0, 1024);
@@ -409,14 +388,6 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     anim2_start_called = 0;
     anim2_completed_called = 0;
 
-    lv_memcpy(&anim3, &anim1, sizeof(anim1));
-    lv_anim_set_duration(&anim3, 200);
-    lv_anim_set_exec_cb(&anim3, anim3_exec_cb);
-    lv_anim_set_start_cb(&anim3, anim3_start);
-    lv_anim_set_completed_cb(&anim3, anim3_completed);
-    anim3_start_called = 0;
-    anim3_completed_called = 0;
-
     lv_anim_timeline_t * timeline = lv_anim_timeline_create();
     lv_anim_timeline_add(timeline,   0, &anim1);
     lv_anim_timeline_add(timeline, 200, &anim2);
@@ -427,8 +398,8 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     /*
      *   |-----anim1-----|
      *           |-anim2-|
-     *                       |--anim3---|
-     *   0       200   300  400  500  600
+     *                    
+     *   0       200   300
      */
 
     lv_test_wait(20); /*Wait 20 ms*/
@@ -436,24 +407,18 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(0, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
-    TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
     lv_test_wait(200); /*Now we are at 220ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
-    TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
     lv_test_wait(100); /*Now we are at 320ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(1, anim2_completed_called);
-    TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -391,7 +391,6 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     lv_anim_timeline_t * timeline = lv_anim_timeline_create();
     lv_anim_timeline_add(timeline,   0, &anim1);
     lv_anim_timeline_add(timeline, 200, &anim2);
-    lv_anim_timeline_add(timeline, 400, &anim3);
     lv_anim_timeline_start(timeline);
 
 
@@ -414,6 +413,11 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
 
+    lv_test_wait(100); /*Now we are at 320ms */
+    TEST_ASSERT_EQUAL(1, anim1_start_called);
+    TEST_ASSERT_EQUAL(1, anim1_completed_called);
+    TEST_ASSERT_EQUAL(1, anim2_start_called);
+    TEST_ASSERT_EQUAL(0, anim2_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -418,6 +418,8 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
+
+    lv_test_wait(200); /*Now we are at 520ms */
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -380,7 +380,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     anim1_completed_called = 0;
 
     lv_memcpy(&anim2, &anim1, sizeof(anim1));
-    lv_anim_set_duration(&anim2, 100);
+    lv_anim_set_duration(&anim2, 300);
     lv_anim_set_path_cb(&anim2, lv_anim_path_ease_in);
     lv_anim_set_exec_cb(&anim2, anim2_exec_cb);
     lv_anim_set_start_cb(&anim2, anim2_start);
@@ -397,9 +397,9 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
 
     /*
      *   |-----anim1-----|
-     *           |-anim2-|
+     *           |----anim2----|
      *                    
-     *   0       200   300
+     *   0       200   300    500
      */
 
     lv_test_wait(20); /*Wait 20 ms*/
@@ -414,11 +414,11 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(1, anim2_start_called);
     TEST_ASSERT_EQUAL(0, anim2_completed_called);
 
-    lv_test_wait(90); /*Now we are at 310ms */
+    lv_test_wait(100); /*Now we are at 320ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(1, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called);
+    TEST_ASSERT_EQUAL(0, anim2_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -431,7 +431,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
      *   0       200   300  400  500  600
      */
 
-    lv_test_wait(10); /*Wait 10 ms*/
+    lv_test_wait(20); /*Wait 20 ms*/
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(0, anim2_start_called);
@@ -439,7 +439,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(0, anim3_start_called);
     TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(200); /*Now we are at 210ms */
+    lv_test_wait(200); /*Now we are at 220ms */
     TEST_ASSERT_EQUAL(1, anim1_start_called);
     TEST_ASSERT_EQUAL(0, anim1_completed_called);
     TEST_ASSERT_EQUAL(1, anim2_start_called);
@@ -447,29 +447,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     TEST_ASSERT_EQUAL(0, anim3_start_called);
     TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(100); /*Now we are at 310ms */
-    TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called);
-    TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called);
-    TEST_ASSERT_EQUAL(0, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called);
 
-    lv_test_wait(105); /*Now we are at 410ms */
-    TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called);
-    TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called);
-    TEST_ASSERT_EQUAL(1, anim3_start_called);
-    TEST_ASSERT_EQUAL(0, anim3_completed_called);
-
-    lv_test_wait(200); /*Now we are at 610ms */
-    TEST_ASSERT_EQUAL(1, anim1_start_called);
-    TEST_ASSERT_EQUAL(1, anim1_completed_called);
-    TEST_ASSERT_EQUAL(1, anim2_start_called);
-    TEST_ASSERT_EQUAL(1, anim2_completed_called);
-    TEST_ASSERT_EQUAL(1, anim3_start_called);
-    TEST_ASSERT_EQUAL(1, anim3_completed_called);
 }
 
 #endif

--- a/tests/src/test_cases/test_anim_timeline.c
+++ b/tests/src/test_cases/test_anim_timeline.c
@@ -398,7 +398,7 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
     /*
      *   |-----anim1-----|
      *           |----anim2----|
-     *                    
+     *
      *   0       200   300    500
      */
 
@@ -422,3 +422,5 @@ void test_anim_timeline_with_anim_start_cb_and_completed_cb(void)
 }
 
 #endif
+
+


### PR DESCRIPTION
anim_timeline  can call  anim's completed_cb

### Description of the feature or fix

The `anim_timeline` can call the `anim's complete_cb` function.

When the `anim_timeline` moves forward, 
it should call the `anim's complete_cb` 
when the animation reaches the `end_value`.

And when the `anim_timeline` reverses, 
it should call the `anim's complete_cb` 
when the animation reaches the `start_value`.

### Example
```c
#include "../lv_examples.h"
#if LV_BUILD_EXAMPLES

void anim1_exec_cb(void *var , int32_t v){
  printf("[anim1] %d\n", v);
};

void anim2_exec_cb(void *var , int32_t v){
  printf("[anim2] %d\n", v);
};

void anim3_exec_cb(void *var , int32_t v){
  printf("[anim3] %d\n", v);
};

void anim1_completed(lv_anim_t*a){
  printf("[anim1] completed\n");
}

void anim2_completed(lv_anim_t*a){
  printf("[anim2] completed\n");
}

void anim3_completed(lv_anim_t*a){
  printf("[anim3] completed\n");
}

void lv_example_anim_timeline_2(void){

  lv_anim_t anim1;
  lv_anim_t anim2;
  lv_anim_t anim3;

  lv_anim_init(&anim1);
  lv_anim_set_values(&anim1, 0,1024);
  lv_anim_set_duration(&anim1, 300);
  lv_anim_set_exec_cb(&anim1, anim1_exec_cb);
  lv_anim_set_completed_cb(&anim1, anim1_completed);

  lv_memcpy(&anim2, &anim1, sizeof(anim1));
  lv_anim_set_duration(&anim2, 100);
  lv_anim_set_path_cb(&anim2, lv_anim_path_ease_in);
  lv_anim_set_exec_cb(&anim2, anim2_exec_cb);
  lv_anim_set_completed_cb(&anim2, anim2_completed);

  lv_memcpy(&anim3, &anim1, sizeof(anim1));
  lv_anim_set_duration(&anim3, 200);
  lv_anim_set_exec_cb(&anim3, anim3_exec_cb);
  lv_anim_set_completed_cb(&anim3, anim3_completed);

  lv_anim_timeline_t *timeline = lv_anim_timeline_create();
  lv_anim_timeline_add(timeline,   0, &anim1);
  lv_anim_timeline_add(timeline, 200, &anim2);
  lv_anim_timeline_add(timeline, 400, &anim3);
  lv_anim_timeline_start(timeline);
}

#endif

```
